### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-#DestroyTwitter
+# DestroyTwitter
 
-##Warning
+## Warning
 The code you are about to see might scare small children. Please don't hate me for its lack of unit testing, documentation, and cleanliness. As a one man team trying to keep the app up-to-date with the latest Twitter features, I hurried a few areas of the app, so there are many inconsiderate implementations. If you'd like to go in and just clean up everything, feel free. I'd actually buy you dinner if you would.
 
-##Why open source it?
+## Why open source it?
 I decided to open source DestroyTwitter because I'm not as available to maintain it as I was when the project started. I started DestroyTwitter when I was in college and had much more free time back then. Now that I have an actual job keeping me busy, I can't keep up with the needed bug fixes and features.
 
-##License in a nutshell
+## License in a nutshell
 Under the GNU General Public License, you can work on the app and share it as long as you don't charge anything. I kept DestroyTwitter free over the past few years and so should you.
 
-##Don'ts
+## Don'ts
 Please don't submit your own build of DestroyTwitter to an app store saying it's the official client. Chances are it won't make it past approval because "Destroy" and "Twitter". I'll publish the official builds through pull requests.
 
-##Consumer key and secret
+## Consumer key and secret
 Twitter requires a consumer key and secret registered through the dev section of their website. Feel free to register your own build, but only the official build will use the "via DestroyTwitter" key/secret for security reasons. We don't want someone making a malicious app with the key/secret, provoking Twitter to ban DestroyTwitter.
 
-##Discussions
+## Discussions
 Use the IRC channel #destroytwitter on freenode.net to discuss anything related to DestroyTwitter. I'll try to be on as often as I can to answer questions or contribute to decision-making.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
